### PR TITLE
Updates for pydantic v2

### DIFF
--- a/ci/environment-docs.yml
+++ b/ci/environment-docs.yml
@@ -12,7 +12,7 @@ dependencies:
   - myst-nb
   - netcdf4
   - pip
-  - pydantic<2.0 # Will remove in upcoming PR
+  - pydantic>=2.0
   - s3fs
   - sphinx-copybutton
   - sphinx-inline-tabs

--- a/ci/environment-docs.yml
+++ b/ci/environment-docs.yml
@@ -1,4 +1,4 @@
-name: ecgtools-dev
+name: ecgtools-doc
 channels:
   - conda-forge
   - nodefaults
@@ -19,7 +19,6 @@ dependencies:
   - xarray
   - pip:
       - sphinxext-opengraph
-      - autodoc_pydantic
       - -r ../requirements.txt
       - git+https://github.com/intake/intake-esm
       - -e ..

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - numpydoc
   - pip
   - pre-commit
-  - pydantic<2.0 # Will remove in upcoming PR
+  - pydantic>=2.0
   - pytest
   - pytest-cov
   - pytest-sugar

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - netcdf4
   - pip
   - pre-commit
-  - pydantic<2.0 # Will remove in upcoming PR
+  - pydantic>=2.0
   - pytest
   - pytest-cov
   - pytest-sugar

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,6 @@ extensions = [
     'myst_nb',
     'sphinxext.opengraph',
     'sphinx_copybutton',
-    'sphinxcontrib.autodoc_pydantic',
     'sphinx_inline_tabs',
 ]
 
@@ -30,10 +29,6 @@ myst_url_schemes = ['http', 'https', 'mailto']
 # sphinx-copybutton configurations
 copybutton_prompt_text = r'>>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: '
 copybutton_prompt_is_regexp = True
-
-
-autodoc_pydantic_model_show_json = True
-autodoc_pydantic_settings_show_json = False
 
 jupyter_execute_notebooks = 'off'
 execution_timeout = 600

--- a/ecgtools/builder.py
+++ b/ecgtools/builder.py
@@ -146,7 +146,7 @@ class Builder:
         return self
 
     @pydantic.validate_arguments
-    def parse(self, *, parsing_func: typing.Callable, parsing_func_kwargs: dict = None):
+    def parse(self, *, parsing_func: typing.Callable, parsing_func_kwargs: typing.Optional[dict] = None):
         if not self.assets:
             raise ValueError('asset list provided is None. Please run `.get_assets()` first')
 

--- a/ecgtools/builder.py
+++ b/ecgtools/builder.py
@@ -146,7 +146,9 @@ class Builder:
         return self
 
     @pydantic.validate_arguments
-    def parse(self, *, parsing_func: typing.Callable, parsing_func_kwargs: typing.Optional[dict] = None):
+    def parse(
+        self, *, parsing_func: typing.Callable, parsing_func_kwargs: typing.Optional[dict] = None
+    ):
         if not self.assets:
             raise ValueError('asset list provided is None. Please run `.get_assets()` first')
 

--- a/ecgtools/builder.py
+++ b/ecgtools/builder.py
@@ -109,13 +109,13 @@ class Builder:
     """
 
     paths: typing.List[str]
-    storage_options: typing.Dict[typing.Any, typing.Any] = None
+    storage_options: typing.Optional[typing.Dict[typing.Any, typing.Any]] = None
     depth: int = 0
-    exclude_patterns: typing.List[str] = None
-    include_patterns: typing.List[str] = None
-    joblib_parallel_kwargs: typing.Dict[str, typing.Any] = None
+    exclude_patterns: typing.Optional[typing.List[str]] = None
+    include_patterns: typing.Optional[typing.List[str]] = None
+    joblib_parallel_kwargs: typing.Optional[typing.Dict[str, typing.Any]] = None
 
-    def __post_init_post_parse__(self):
+    def __post_init__(self):
         self.storage_options = self.storage_options or {}
         self.joblib_parallel_kwargs = self.joblib_parallel_kwargs or {}
         self.exclude_patterns = self.exclude_patterns or []
@@ -177,9 +177,9 @@ class Builder:
         self,
         *,
         parsing_func: typing.Callable,
-        parsing_func_kwargs: dict = None,
-        postprocess_func: typing.Callable = None,
-        postprocess_func_kwargs: dict = None,
+        parsing_func_kwargs: typing.Optional[dict] = None,
+        postprocess_func: typing.Optional[typing.Callable] = None,
+        postprocess_func_kwargs: typing.Optional[dict] = None,
     ):
         """Builds a catalog from a list of netCDF files or zarr stores.
 
@@ -218,14 +218,14 @@ class Builder:
         path_column_name: str,
         variable_column_name: str,
         data_format: DataFormat,
-        groupby_attrs: typing.List[str] = None,
-        aggregations: typing.List[Aggregation] = None,
+        groupby_attrs: typing.Optional[typing.List[str]] = None,
+        aggregations: typing.Optional[typing.List[Aggregation]] = None,
         esmcat_version: str = '0.0.1',
-        description: str = None,
-        directory: str = None,
+        description: typing.Optional[str] = None,
+        directory: typing.Optional[str] = None,
         catalog_type: str = 'file',
-        to_csv_kwargs: dict = None,
-        json_dump_kwargs: dict = None,
+        to_csv_kwargs: typing.Optional[dict] = None,
+        json_dump_kwargs: typing.Optional[dict] = None,
     ):
         """Persist catalog contents to files.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ joblib
 netCDF4
 xarray
 pyyaml
-pydantic
+pydantic>=2.0
 pandas
 fsspec
 intake-esm


### PR DESCRIPTION
## Change Summary

This PR implements changes required for ecgtools to update to the recently-released pydantic v2. Test are still failing because Intake-ESM also requires changes to update to pydantic v2 (see https://github.com/intake/intake-esm/pull/619).

Unfortunately the `autodoc_pydantic` Sphinx extension does not support pydantic v2. Thus the docs build is also failing.

It doesn't look like `autodoc_pydantic` will support pydantic v2 any time soon (see https://github.com/mansenfranzen/autodoc_pydantic/issues/146) so the API section of the docs will potentially be poorly formatted for a while if we want to update ecgtools and Intake-ESM to use pydantic v2.

Another option is to pin pydantic<2.0 in both ecgtools and Intake-ESM, but that has it's own (probably worse?) problems.

## Related issue number

Closes #161 

## Checklist

- [x] Unit tests for the changes exist
- [ ] Tests pass on CI (Intake-ESM needs updated also)
