### PR TITLE
Update Intake-ESM version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyyaml
 pydantic
 pandas
 fsspec
-intake-esm
+intake-esm>=2023.7.7


### PR DESCRIPTION
## Change Summary

Apologies, I forgot to do this earlier. ecgtools>=2023.7.7 only works with Intake-ESM>=2023.7.7. This PR adds this to the requirements.

This requirement should also be added to the [ecgtools-feedstock recipe](https://github.com/conda-forge/ecgtools-feedstock/blob/4277f4c79bf24e762fd86614d53df314f8592ce9/recipe/meta.yaml#L35) and then hopefully that will run successfully since Intake-ESM=2023.7.7 is now available on conda-forge.

