### PR TITLE
Replace `pkg_resources` with `importlib`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - name: Create conda environment

--- a/ecgtools/__init__.py
+++ b/ecgtools/__init__.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # flake8: noqa
 """Top-level module for ecgtools ."""
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 from .builder import Builder, RootDirectory, glob_to_regex
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
     __version__ = '0.0.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=ecgtools
-known_third_party=cf_xarray,joblib,pandas,pkg_resources,pydantic,pytest,setuptools,xarray
+known_third_party=cf_xarray,joblib,pandas,pydantic,pytest,setuptools,xarray
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

`pkg_resources` was used in `ecgtools` to get the version, but `pkg_resources` has been removed in Python 3.12. This PR replaces uses of `pkg_resources` with `importlib`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

- Closes #185 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI

<!--
Please add any other relevant info below:
-->
